### PR TITLE
Remove window chrome from iOS 8

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
   <link rel="manifest" href="manifest.json">
   <link href='http://fonts.googleapis.com/css?family=Open+Sans:700,400' rel='stylesheet' type='text/css'>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">
-  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
+  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
   <title>Rotten Tomatoes - React Native Sample App</title>
   <link rel="stylesheet" type="text/css" href="main.css">
   <script src="touch-emulator.js"></script>


### PR DESCRIPTION
Deleted old meta tag to remove window chrome on iOS 7 and lower. Added correct meta tag for iOS 8.
